### PR TITLE
Fix default parameter bug

### DIFF
--- a/keywords_cloud.ipynb
+++ b/keywords_cloud.ipynb
@@ -98,7 +98,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def generate_cloud(languages: set, highlights: dict = {}):\n",
+    "def generate_cloud(languages: set, highlights: dict | None = None):\n",
+    "    if highlights is None:\n",
+    "        highlights = {}\n",
     "    \"\"\" function using Wordcloud to generate a... word cloud\n",
     "\n",
     "    :param languages: a set of languages, these have to be one of the existing ones listed in the `urls`\n",


### PR DESCRIPTION
## Summary
- avoid using mutable default argument for highlights

## Testing
- `python - <<'EOF'
import json, ast
nb=json.load(open('keywords_cloud.ipynb'))
code='\n'.join(''.join(c['source']) for c in nb['cells'] if c['cell_type']=='code')
try:
    ast.parse(code)
    print('syntax ok')
except Exception as e:
    print('syntax error', e)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68556ac9197c832497f69933907c5120