### PR TITLE
Fix wordcloud capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Create a cloud of keywords for a few programming languages, with optional highli
 
 ## Requirements
 
-- [Wordcloud](https://github.com/amueller/word_cloud): `pip install wordcloud`
+- [wordcloud](https://github.com/amueller/word_cloud): `pip install wordcloud`
 
 #### Installation notes
 
@@ -14,4 +14,4 @@ wordcloud depends on `numpy` and `pillow`.
 To save the wordcloud into a file, `matplotlib` can also be installed.
 
 
-Please see [Wordcloud's GitHub](https://github.com/amueller/word_cloud) for more info on requirements and example usage.
+Please see [wordcloud's GitHub](https://github.com/amueller/word_cloud) for more info on requirements and example usage.


### PR DESCRIPTION
## Summary
- standardize `wordcloud` name in docs

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68556d75843c8324984c5b28b078c409