### PR TITLE
Add pytest for get_keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,19 @@ To save the wordcloud into a file, `matplotlib` can also be installed.
 
 
 Please see [Wordcloud's GitHub](https://github.com/amueller/word_cloud) for more info on requirements and example usage.
+## Using `get_keywords`
+
+The `keywords_cloud` module exposes a helper function `get_keywords(language)` which returns the list of reserved words for the chosen language. For Python, it simply returns `keyword.kwlist`.
+
+```python
+from keywords_cloud import get_keywords
+print(get_keywords("python"))
+```
+
+## Running tests
+
+Install `pytest` and run:
+
+```bash
+pytest -q
+```

--- a/keywords_cloud.py
+++ b/keywords_cloud.py
@@ -1,0 +1,55 @@
+import re
+import keyword
+
+try:  # Optional imports for non-python languages
+    from bs4 import BeautifulSoup
+    from urllib.request import urlopen
+except Exception:  # pragma: no cover - only needed when dependencies missing
+    BeautifulSoup = None  # type: ignore
+    urlopen = None  # type: ignore
+
+# List of usable urls to extract the keywords
+urls = {
+    'c#': {
+        "url": "https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/",
+        "tag": "code"
+    },
+    'c++': {
+        "url": "https://learn.microsoft.com/en-us/cpp/cpp/keywords-cpp",
+        "tag": "code"
+    },
+    't-sql': {
+        "url": "https://learn.microsoft.com/en-us/sql/t-sql/language-elements/reserved-keywords-transact-sql",
+        "tag": "p"
+    },
+    'javascript': {
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords",
+        "tag": "code"
+    },
+    'java': {
+        "url": "https://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html",
+        "tag": "code"
+    }
+}
+
+def get_keywords(language: str):
+    """Return a list of keywords for the given language."""
+    lang = language.lower()
+
+    # Python keywords can be retrieved directly
+    if lang == 'python':
+        return keyword.kwlist
+
+    match_word = lambda x: len(re.findall(r'\w+', str(x)))
+
+    if lang in urls and BeautifulSoup and urlopen:
+        page = urlopen(urls[lang]['url'])
+        html = page.read().decode("utf-8")
+        soup = BeautifulSoup(html, "html.parser")
+        return [
+            c.string
+            for c in soup.find_all(urls[lang]['tag'])
+            if (match_word(c.string) == 1 and c.string is not None)
+        ]
+
+    return []

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,0 +1,5 @@
+import keyword
+from keywords_cloud import get_keywords
+
+def test_get_python_keywords():
+    assert get_keywords("python") == keyword.kwlist


### PR DESCRIPTION
## Summary
- implement `keywords_cloud.get_keywords` in a standalone module
- add minimal pytest suite ensuring Python keywords are returned
- document how to call `get_keywords` and run the tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68556d822e908324adf3c9b7ec9e4b44